### PR TITLE
Unlimited item battery & GUI adjustments & hide watermark

### DIFF
--- a/r.e.p.o cheat/Cheats/UnlimitedBattery.cs
+++ b/r.e.p.o cheat/Cheats/UnlimitedBattery.cs
@@ -1,0 +1,179 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace r.e.p.o_cheat
+{
+    public class UnlimitedBattery : MonoBehaviour
+    {
+        public bool unlimitedBatteryEnabled = false;
+        private float updateInterval = 2f;
+        private List<ItemBattery> batteries = new List<ItemBattery>();
+        private float nextScanTime = 0f;
+        private const float SCAN_INTERVAL = 2f;
+        private Dictionary<System.Type, FieldInfo> batteryLifeIntCache = new Dictionary<System.Type, FieldInfo>();
+        private Dictionary<System.Type, FieldInfo> batteryDrainRateCache = new Dictionary<System.Type, FieldInfo>();
+        private Dictionary<System.Type, FieldInfo> drainTimerCache = new Dictionary<System.Type, FieldInfo>();
+        private Dictionary<System.Type, MethodInfo> batteryFullPercentChangeCache = new Dictionary<System.Type, MethodInfo>();
+
+        void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+            StartCoroutine(BatteryUpdateCoroutine());
+        }
+
+        void OnDestroy()
+        {
+            StopAllCoroutines();
+        }
+
+        bool IsLocalPlayerHolding(ItemBattery battery)
+        {
+            if (battery == null) return false;
+
+            var physGrabObject = battery.GetComponent<PhysGrabObject>();
+            if (physGrabObject == null) return false;
+
+            if (physGrabObject.playerGrabbing != null && physGrabObject.playerGrabbing.Count > 0)
+            {
+                foreach (var grabber in physGrabObject.playerGrabbing)
+                {
+                    if (grabber != null && grabber.isLocal)
+                        return true;
+                }
+            }
+
+            var equippable = battery.GetComponent<ItemEquippable>();
+            if (equippable != null)
+            {
+                var isEquippedField = equippable.GetType().GetField("isEquipped", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+                if (isEquippedField != null && (bool)isEquippedField.GetValue(equippable))
+                {
+                    var playerAvatarLocal = SemiFunc.PlayerAvatarLocal();
+                    if (playerAvatarLocal != null)
+                    {
+                        var itemSlots = playerAvatarLocal.GetType().GetField("itemSlots", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                        if (itemSlots != null)
+                        {
+                            var slots = itemSlots.GetValue(playerAvatarLocal) as System.Collections.IEnumerable;
+                            if (slots != null)
+                            {
+                                foreach (var slot in slots)
+                                {
+                                    var itemField = slot.GetType().GetField("item", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                                    if (itemField != null)
+                                    {
+                                        var item = itemField.GetValue(slot) as GameObject;
+                                        if (item != null && item == battery.gameObject)
+                                            return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        void UpdateBatteryCache()
+        {
+            if (Time.time >= nextScanTime)
+            {
+                batteries.RemoveAll(b => b == null);
+                ItemBattery[] newBatteries = FindObjectsOfType<ItemBattery>();
+                foreach (ItemBattery battery in newBatteries)
+                {
+                    if (!batteries.Contains(battery) && battery != null)
+                        batteries.Add(battery);
+                }
+                nextScanTime = Time.time + SCAN_INTERVAL;
+            }
+        }
+
+        IEnumerator BatteryUpdateCoroutine()
+        {
+            yield return new WaitForSeconds(1f);
+
+            while (true)
+            {
+                if (unlimitedBatteryEnabled)
+                {
+                    UpdateBatteryCache();
+
+                    for (int i = 0; i < batteries.Count; i++)
+                    {
+                        ItemBattery battery = batteries[i];
+                        if (battery == null) continue;
+
+                        if (IsLocalPlayerHolding(battery))
+                        {
+                            battery.batteryLife = 100f;
+                            System.Type t = battery.GetType();
+
+                            FieldInfo batteryLifeIntField;
+                            if (!batteryLifeIntCache.TryGetValue(t, out batteryLifeIntField))
+                            {
+                                batteryLifeIntField = t.GetField("batteryLifeInt", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                                batteryLifeIntCache[t] = batteryLifeIntField;
+                            }
+
+                            if (batteryLifeIntField != null)
+                            {
+                                int currentLifeInt = (int)batteryLifeIntField.GetValue(battery);
+                                if (currentLifeInt < 6)
+                                {
+                                    batteryLifeIntField.SetValue(battery, 6);
+                                }
+                            }
+
+                            FieldInfo drainRateField;
+                            if (!batteryDrainRateCache.TryGetValue(t, out drainRateField))
+                            {
+                                drainRateField = t.GetField("batteryDrainRate", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                                batteryDrainRateCache[t] = drainRateField;
+                            }
+
+                            if (drainRateField != null)
+                                drainRateField.SetValue(battery, 0f);
+
+                            FieldInfo drainTimerField;
+                            if (!drainTimerCache.TryGetValue(t, out drainTimerField))
+                            {
+                                drainTimerField = t.GetField("drainTimer", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                                drainTimerCache[t] = drainTimerField;
+                            }
+
+                            if (drainTimerField != null)
+                                drainTimerField.SetValue(battery, 0f);
+
+                            MethodInfo updateVisuals;
+                            if (!batteryFullPercentChangeCache.TryGetValue(t, out updateVisuals))
+                            {
+                                updateVisuals = t.GetMethod("BatteryFullPercentChange", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                                batteryFullPercentChangeCache[t] = updateVisuals;
+                            }
+
+                            if (updateVisuals != null)
+                            {
+                                int currentLifeInt = batteryLifeIntField != null ? (int)batteryLifeIntField.GetValue(battery) : 0;
+                                if (currentLifeInt < 6)
+                                {
+                                    updateVisuals.Invoke(battery, new object[] { 6, true });
+                                }
+                            }
+                        }
+
+                        if ((i + 1) % 5 == 0)
+                            yield return null;
+                    }
+                }
+
+                yield return new WaitForSeconds(updateInterval);
+            }
+        }
+    }
+}

--- a/r.e.p.o cheat/Utils/HotkeyManager.cs
+++ b/r.e.p.o cheat/Utils/HotkeyManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using r.e.p.o_cheat;
 
 namespace r.e.p.o_cheat
 {

--- a/r.e.p.o cheat/Utils/HotkeyManager.cs
+++ b/r.e.p.o cheat/Utils/HotkeyManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using r.e.p.o_cheat;
 
 namespace r.e.p.o_cheat
 {
@@ -48,6 +49,7 @@ namespace r.e.p.o_cheat
         private HotkeyManager()
         {
             InitializeHotkeyActions();
+            InitializeUnlimitedBatteryAction();
             LoadHotkeySettings();
         }
 
@@ -68,6 +70,16 @@ namespace r.e.p.o_cheat
                 Action = action;
                 Description = description;
             }
+        }
+
+        private void InitializeUnlimitedBatteryAction()
+        {
+            availableActions.Add(new HotkeyAction("Unlimited Battery", () =>
+            {
+                Hax2.unlimitedBatteryActive = !Hax2.unlimitedBatteryActive;
+                if (Hax2.unlimitedBatteryComponent != null)
+                    Hax2.unlimitedBatteryComponent.unlimitedBatteryEnabled = Hax2.unlimitedBatteryActive;
+            }, "toggles unlimited battery on/off"));
         }
 
         private void InitializeHotkeyActions()
@@ -178,6 +190,14 @@ namespace r.e.p.o_cheat
                 PlayerController.RemoveSpeed(Hax2.sliderValueStrength);
                 DLog.Log("speed set to normal (5)");
             }, "sets speed to normal value"));
+
+            availableActions.Add(new HotkeyAction("Unlimited Battery", () =>
+            {
+                Hax2.unlimitedBatteryActive = !Hax2.unlimitedBatteryActive;
+                if (Hax2.unlimitedBatteryComponent != null)
+                    Hax2.unlimitedBatteryComponent.unlimitedBatteryEnabled = Hax2.unlimitedBatteryActive;
+            }, "toggles unlimited battery on/off"));
+
 
             for (int i = 0; i < defaultHotkeys.Length; i++)
             {

--- a/r.e.p.o cheat/hax.cs
+++ b/r.e.p.o cheat/hax.cs
@@ -7,6 +7,7 @@ using Photon.Pun;
 using Photon.Realtime;
 using System.Linq;
 
+
 namespace r.e.p.o_cheat
 {
     public static class UIHelper
@@ -142,6 +143,8 @@ namespace r.e.p.o_cheat
         public static bool godModeActive = false;
         public static bool infiniteHealthActive = false;
         public static bool stamineState = false;
+        public static bool unlimitedBatteryActive = false;
+        public static UnlimitedBattery unlimitedBatteryComponent;
         private Vector2 playerScrollPosition = Vector2.zero;
         private Vector2 enemyScrollPosition = Vector2.zero;
         private int teleportPlayerSourceIndex = 0;  // Default to first player in list
@@ -213,6 +216,8 @@ namespace r.e.p.o_cheat
         
         private HotkeyManager hotkeyManager; // Reference to the HotkeyManager
 
+        public bool showWatermark = true;
+
         private float actionSelectorX = 300f;
         private float actionSelectorY = 200f;
         private bool isDraggingActionSelector = false;
@@ -246,6 +251,13 @@ namespace r.e.p.o_cheat
             UpdateCursorState();
             hotkeyManager = HotkeyManager.Instance;
             hotkeyManager.Initialize();
+
+            if (unlimitedBatteryComponent == null)
+            {
+                GameObject batteryObj = new GameObject("BatteryManager");
+                unlimitedBatteryComponent = batteryObj.AddComponent<UnlimitedBattery>();
+                DontDestroyOnLoad(batteryObj);
+            }
 
             DebugCheats.texture2 = new Texture2D(2, 2, TextureFormat.ARGB32, false);
             DebugCheats.texture2.SetPixels(new[] { Color.red, Color.red, Color.red, Color.red });
@@ -575,8 +587,14 @@ namespace r.e.p.o_cheat
 
             if (DebugCheats.drawEspBool || DebugCheats.drawItemEspBool || DebugCheats.drawExtractionPointEspBool || DebugCheats.drawPlayerEspBool || DebugCheats.draw3DPlayerEspBool || DebugCheats.draw3DItemEspBool || DebugCheats.drawChamsBool) DebugCheats.DrawESP();
 
-            GUI.Label(new Rect(10, 10, 200, 30), $"D.A.R.K CHEAT | {hotkeyManager.MenuToggleKey} - MENU");
-            GUI.Label(new Rect(230, 10, 200, 30), "MADE BY Github/D4rkks");
+            GUIStyle style = new GUIStyle(GUI.skin.label) { wordWrap = false };
+            if (showWatermark)
+            {
+                GUIContent content = new GUIContent($"D.A.R.K CHEAT | {hotkeyManager.MenuToggleKey} - MENU");
+                Vector2 size = style.CalcSize(content);
+                GUI.Label(new Rect(10, 10, size.x, size.y), content, style);
+                GUI.Label(new Rect(10 + size.x + 10, 10, 200, size.y), "MADE BY Github/D4rkks", style);
+            }
 
             // handle modal first
             if (showingActionSelector)
@@ -929,6 +947,7 @@ namespace r.e.p.o_cheat
                             DLog.Log("Randomize toggled: " + playerColor.isRandomizing);
                         }
 
+
                         UIHelper.Label("Flashlight Intensity: " + Hax2.flashlightIntensity, menuX + 30, menuY + 185);
                         Hax2.flashlightIntensity = UIHelper.Slider(Hax2.flashlightIntensity, 1f, 100f, menuX + 30, menuY + 205);
 
@@ -1007,6 +1026,20 @@ namespace r.e.p.o_cheat
                         if (newNoFogState != MiscFeatures.NoFogEnabled)
                         {
                             MiscFeatures.ToggleNoFog(newNoFogState);
+                        }
+
+                        bool newUnlimitedBatteryState = UIHelper.ButtonBool("Toggle Unlimited Battery", unlimitedBatteryActive, menuX + 30, menuY + 605);
+                        if (newUnlimitedBatteryState != unlimitedBatteryActive)
+                        {
+                            unlimitedBatteryActive = newUnlimitedBatteryState;
+                            if (unlimitedBatteryComponent != null)
+                                unlimitedBatteryComponent.unlimitedBatteryEnabled = unlimitedBatteryActive;
+                        }
+
+                        bool newWatermarkState = UIHelper.ButtonBool("Disable Watermark", !showWatermark, menuX + 30, menuY + 645);
+                        if (newWatermarkState != !showWatermark)
+                        {
+                            showWatermark = !newWatermarkState;
                         }
                         break;
 

--- a/r.e.p.o cheat/r.e.p.o cheat.csproj
+++ b/r.e.p.o cheat/r.e.p.o cheat.csproj
@@ -370,6 +370,7 @@
   <ItemGroup>
     <Compile Include="Cheats\CrashLobby.cs" />
     <Compile Include="Cheats\Enemies.cs" />
+    <Compile Include="Cheats\UnlimitedBattery.cs" />
     <Compile Include="Utils\DebugController.cs" />
     <Compile Include="Utils\disablemethod.cs" />
     <Compile Include="Utils\HotkeyManager.cs" />


### PR DESCRIPTION
- added unlimited battery for host only, does not affect items held by other players
- added hotkey action
- scanning for battery values every 1second, can be decreased for performance
- long keycodes for menu open key should no longer cause wrap
- added disable watermark to misc tab